### PR TITLE
[2022.10.16] Login Screen 레이아웃 완성

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,38 +1,40 @@
 import { useEffect } from "react";
 import { SERVER_PORT } from "@env";
 import { io } from "socket.io-client";
-import { StatusBar } from "expo-status-bar";
 import { Platform } from "react-native";
+import { StatusBar } from "expo-status-bar";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import MainScreen from "./src/screen/MainScreen";
+import LoginScreen from "./src/screen/LoginScreen";
 
 export default function App() {
   const Stack = createNativeStackNavigator();
 
-  useEffect(() => {
-    const socket = io(`${SERVER_PORT}`);
+  // ## Socket TEST
+  // useEffect(() => {
+  //   const socket = io(`${SERVER_PORT}`);
 
-    if (Platform.OS === "web") {
-      window.addEventListener("keydown", (e) => {
-        if (e.keyCode === 37) {
-          socket.emit("user-send", "left");
-        } else if (e.keyCode === 38) {
-          socket.emit("user-send", "up");
-        } else if (e.keyCode === 39) {
-          socket.emit("user-send", "right");
-        } else if (e.keyCode === 40) {
-          socket.emit("user-send", "down");
-        }
-      });
+  //   if (Platform.OS === "web") {
+  //     window.addEventListener("keydown", (e) => {
+  //       if (e.keyCode === 37) {
+  //         socket.emit("user-send", "left");
+  //       } else if (e.keyCode === 38) {
+  //         socket.emit("user-send", "up");
+  //       } else if (e.keyCode === 39) {
+  //         socket.emit("user-send", "right");
+  //       } else if (e.keyCode === 40) {
+  //         socket.emit("user-send", "down");
+  //       }
+  //     });
 
-      socket.on("broadcast");
+  //     socket.on("broadcast");
 
-      return () => {
-        socket.disconnect();
-      };
-    }
-  });
+  //     return () => {
+  //       socket.disconnect();
+  //     };
+  //   }
+  // });
 
   return (
     <NavigationContainer>
@@ -42,6 +44,7 @@ export default function App() {
         screenOptions={{ headerShown: false }}
       >
         <Stack.Screen name="Main" component={MainScreen} />
+        <Stack.Screen name="Login" component={LoginScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portable-trackpad-client",
       "version": "1.0.0",
       "dependencies": {
+        "@expo/vector-icons": "^13.0.0",
         "@expo/webpack-config": "^0.17.0",
         "@react-navigation/native": "^6.0.13",
         "@react-navigation/native-stack": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/vector-icons": "^13.0.0",
     "@expo/webpack-config": "^0.17.0",
     "@react-navigation/native": "^6.0.13",
     "@react-navigation/native-stack": "^6.9.1",

--- a/src/screen/LoginScreen.js
+++ b/src/screen/LoginScreen.js
@@ -1,0 +1,52 @@
+import styled from "styled-components/native";
+import Ionicons from "@expo/vector-icons/Ionicons";
+
+export default function LoginScreen({ navigation }) {
+  return (
+    <LoginContainer>
+      <LoginPreviousScreenButton onPress={() => navigation.navigate("Main")}>
+        <Ionicons name="arrow-back" size={32} color="#7e94ae" />
+      </LoginPreviousScreenButton>
+      <LoginTitleText>Login</LoginTitleText>
+      <LoginLoginButton>
+        <Ionicons name="logo-google" size={32} color="#f3eee6" />
+        <LoginLoginButtonText>Google Login</LoginLoginButtonText>
+      </LoginLoginButton>
+    </LoginContainer>
+  );
+}
+
+const LoginContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: #f3eee6;
+`;
+
+const LoginTitleText = styled.Text`
+  margin-bottom: 50px;
+  font-size: 60px;
+`;
+
+const LoginLoginButton = styled.TouchableOpacity`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: row;
+  margin-top: 30px;
+  padding: 15px 50px;
+  background-color: #7e94ae;
+  border-radius: 10px;
+`;
+
+const LoginLoginButtonText = styled.Text`
+  margin-left: 10px;
+  font-size: 20px;
+  color: #f3eee6;
+`;
+
+const LoginPreviousScreenButton = styled.TouchableOpacity`
+  position: absolute;
+  top: 40px;
+  left: 20px;
+`;

--- a/src/screen/MainScreen.js
+++ b/src/screen/MainScreen.js
@@ -1,11 +1,11 @@
 import styled from "styled-components/native";
 
-export default function MainPage() {
+export default function MainScreen({ navigation }) {
   return (
     <MainContainer>
-      <MainTitleText>Porterble</MainTitleText>
-      <MainTitleText>Track Pad</MainTitleText>
-      <MainLoginButton>
+      <MainTitleText>Portable</MainTitleText>
+      <MainTitleText>TrackPad</MainTitleText>
+      <MainLoginButton onPress={() => navigation.navigate("Login")}>
         <MainLoginButtonText>Login</MainLoginButtonText>
       </MainLoginButton>
     </MainContainer>
@@ -16,27 +16,25 @@ const MainContainer = styled.View`
   flex: 1;
   justify-content: center;
   align-items: center;
-  min-height: 100vh;
   background-color: #f3eee6;
 `;
 
 const MainTitleText = styled.Text`
-  font-size: 13vmin;
+  font-family: "KoPubWorldMedium";
+  font-size: 50px;
 `;
 
 const MainLoginButton = styled.TouchableOpacity`
   justify-content: center;
   align-items: center;
-  margin-top: 10vh;
-  padding: 3vmin 4vmin;
-  width: 50vw;
-  font-size: 5vmin;
-  color: #f3eee6;
+  margin-top: 80px;
+  padding: 15px 80px;
   background-color: #7e94ae;
-  border-radius: 2vmin;
+  border-radius: 10px;
 `;
 
 const MainLoginButtonText = styled.Text`
-  font-size: 5vmin;
+  font-size: 20px;
+  font-family: "KoPubWorldLight";
   color: #f3eee6;
 `;


### PR DESCRIPTION
# Topic
- Login Screen 레이아웃 완성.

# Detail
- Styled Components 모바일 빌드에서 생기는 오류 해결
- Login Screen Navigation연동 완료.
<img width="372" alt="스크린샷 2022-10-16 오후 5 53 19" src="https://user-images.githubusercontent.com/99075014/196026938-93854819-2c20-4508-a680-1d07bd8e5996.png">

# Kanban Link
https://www.notion.so/vanillacoding/Layout-20fa1c37b57e46318f69076ad9827a11

# Kanban List
- [ ]  유저는 Email과 Password를 입력할 수 있다.
- [ ]  입력된 값을 토대로 `/api/login`에 `POST`요청을 보낸다.
=> 소셜 로그인으로 변경됨에 따라 변경 필요.

# ETC
- React Native navigation테스트를 위해서 만들어놓은 Login테스트용 스크린이었지만
로그인이 소셜로그인으로 바뀜에따라 공식적으로 사용하게됨