### PR TITLE
[2022.10.19] 네트워크 연결 안내페이지 layout 완성

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,7 +8,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import MainScreen from "./src/screen/MainScreen";
 import LoginScreen from "./src/screen/LoginScreen";
 import DesktopAppDownloadScreen from "./src/screen/DesktopAppDownloadScreen";
-import NetworkScreen from "./src/screen/NetworkScreen";
+import NetworkGuideScreen from "./src/screen/NetworkGuideScreen";
 
 export default function App() {
   const Stack = createNativeStackNavigator();
@@ -51,7 +51,7 @@ export default function App() {
           name="DesktopAppDownload"
           component={DesktopAppDownloadScreen}
         />
-        <Stack.Screen name="Network" component={NetworkScreen} />
+        <Stack.Screen name="Network" component={NetworkGuideScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/App.js
+++ b/App.js
@@ -8,6 +8,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import MainScreen from "./src/screen/MainScreen";
 import LoginScreen from "./src/screen/LoginScreen";
 import DesktopAppDownloadScreen from "./src/screen/DesktopAppDownloadScreen";
+import NetworkScreen from "./src/screen/NetworkScreen";
 
 export default function App() {
   const Stack = createNativeStackNavigator();
@@ -50,6 +51,7 @@ export default function App() {
           name="DesktopAppDownload"
           component={DesktopAppDownloadScreen}
         />
+        <Stack.Screen name="Network" component={NetworkScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/screen/DesktopAppDownloadScreen.js
+++ b/src/screen/DesktopAppDownloadScreen.js
@@ -48,7 +48,7 @@ export default function DesktopAppDownloadScreen({ navigation }) {
     const idToken = await AsyncStorage.getItem("idToken");
 
     if (idToken) {
-      navigation.navigate("PcList");
+      navigation.navigate("Network");
     } else {
       Alert.alert("Need Login", "로그인이 필요합니다.", [
         {

--- a/src/screen/NetworkGuideScreen.js
+++ b/src/screen/NetworkGuideScreen.js
@@ -3,7 +3,7 @@ import { Alert } from "react-native";
 import styled from "styled-components/native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-export default function NetworkScreen({ navigation }) {
+export default function NetworkGuideScreen({ navigation }) {
   const logoutAlert = async () => {
     await AsyncStorage.clear();
 

--- a/src/screen/NetworkScreen.js
+++ b/src/screen/NetworkScreen.js
@@ -1,0 +1,100 @@
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { Alert } from "react-native";
+import styled from "styled-components/native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export default function NetworkScreen({ navigation }) {
+  const logoutAlert = async () => {
+    await AsyncStorage.clear();
+
+    Alert.alert("Logout", "로그아웃이 완료되었습니다.", [
+      {
+        text: "확인",
+        onPress: () => navigation.navigate("Main"),
+      },
+    ]);
+  };
+
+  const toNextScreen = async () => {
+    const idToken = await AsyncStorage.getItem("idToken");
+
+    if (idToken) {
+      navigation.navigate("PcList");
+    } else {
+      Alert.alert("Need Login", "로그인이 필요합니다.", [
+        {
+          text: "확인",
+        },
+      ]);
+    }
+  };
+
+  return (
+    <NetworkContainer>
+      <NetworkPreviousScreenButton
+        onPress={() => navigation.navigate("DesktopAppDownload")}
+      >
+        <Ionicons name="arrow-back" size={32} color="#7e94ae" />
+      </NetworkPreviousScreenButton>
+      <NetworkLogoutButton onPress={logoutAlert}>
+        <NetworkLogoutButtonText>Logout</NetworkLogoutButtonText>
+      </NetworkLogoutButton>
+      <Ionicons name="wifi" size={150} color="#7e94ae" />
+      <NetworkText>
+        본 어플리케이션은{"\n"}
+        데스크탑과 디바이스가{"\n"}
+        서로 같은 네트워크에{"\n"}
+        연결되어있어야 합니다.{"\n"}
+      </NetworkText>
+      <NetworkNextButton onPress={toNextScreen}>
+        <NetworkNextButtonText>Next</NetworkNextButtonText>
+      </NetworkNextButton>
+    </NetworkContainer>
+  );
+}
+
+const NetworkContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: #f3eee6;
+`;
+
+const NetworkPreviousScreenButton = styled.TouchableOpacity`
+  position: absolute;
+  top: 40px;
+  left: 20px;
+`;
+
+const NetworkLogoutButton = styled.TouchableOpacity`
+  position: absolute;
+  top: 40px;
+  right: 20px;
+`;
+const NetworkLogoutButtonText = styled.Text`
+  font-size: 20px;
+  margin-right: 10px;
+  color: #7e94ae;
+`;
+
+const NetworkText = styled.Text`
+  margin-bottom: 50px;
+  font-size: 24px;
+  text-align: center;
+`;
+
+const NetworkNextButton = styled.TouchableOpacity`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: row;
+  margin-top: 30px;
+  padding: 15px 50px;
+  background-color: #7e94ae;
+  border-radius: 10px;
+`;
+
+const NetworkNextButtonText = styled.Text`
+  font-size: 20px;
+  color: #f3eee6;
+`;


### PR DESCRIPTION
# Topic
- 네트워크 연결 안내페이지 layout 완성

# Detail
- 이전 화살표 버튼을 누르면 이전 화면(DesktopAppDownload)을 보여준다.
- Logout 버튼을 누르면 로그아웃이 되었다는 안내문구를 보여준다.
- Next 버튼을 누르면 다음 화면(PcList)를 보여준다.
- 네트워크 연결 안내메시지를 보여준다.

<img width="393" alt="image" src="https://user-images.githubusercontent.com/89302818/196507997-6952259b-9dc1-430c-b749-6fab5c6ecf7a.png">


[# Kanban Link
https://www.notion.so/vanillacoding/Layout-7dda471d274744ffacc0e18d66340f46

# Kanban List
- [x]  Next버튼을 눌러서 PC 선택 페이지로 이동할 수 있다.

# ETC
- 해당사항 없음