### PR TITLE
[2022.10.19] PC 연결 스크린 완성

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,43 +1,14 @@
-import { useEffect } from "react";
-import { PACKAGE_SERVER_PORT } from "@env";
-import { io } from "socket.io-client";
-import { Platform } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import MainScreen from "./src/screen/MainScreen";
 import LoginScreen from "./src/screen/LoginScreen";
-import DesktopAppDownloadScreen from "./src/screen/DesktopAppDownloadScreen";
+import DownloadGuideScreen from "./src/screen/DownloadGuideScreen";
 import NetworkGuideScreen from "./src/screen/NetworkGuideScreen";
 import PcListScreen from "./src/screen/PcListScreen";
 
 export default function App() {
   const Stack = createNativeStackNavigator();
-
-  // ## Socket TEST
-  // useEffect(() => {
-  //   const socket = io(`${PACKAGE_SERVER_PORT}`);
-
-  //   if (Platform.OS === "web") {
-  //     window.addEventListener("keydown", (e) => {
-  //       if (e.keyCode === 37) {
-  //         socket.emit("user-send", "left");
-  //       } else if (e.keyCode === 38) {
-  //         socket.emit("user-send", "up");
-  //       } else if (e.keyCode === 39) {
-  //         socket.emit("user-send", "right");
-  //       } else if (e.keyCode === 40) {
-  //         socket.emit("user-send", "down");
-  //       }
-  //     });
-
-  //     socket.on("broadcast");
-
-  //     return () => {
-  //       socket.disconnect();
-  //     };
-  //   }
-  // });
 
   return (
     <NavigationContainer>
@@ -48,10 +19,7 @@ export default function App() {
       >
         <Stack.Screen name="Main" component={MainScreen} />
         <Stack.Screen name="Login" component={LoginScreen} />
-        <Stack.Screen
-          name="DesktopAppDownload"
-          component={DesktopAppDownloadScreen}
-        />
+        <Stack.Screen name="DownloadGuide" component={DownloadGuideScreen} />
         <Stack.Screen name="Network" component={NetworkGuideScreen} />
         <Stack.Screen name="PcList" component={PcListScreen} />
       </Stack.Navigator>

--- a/App.js
+++ b/App.js
@@ -9,6 +9,7 @@ import MainScreen from "./src/screen/MainScreen";
 import LoginScreen from "./src/screen/LoginScreen";
 import DesktopAppDownloadScreen from "./src/screen/DesktopAppDownloadScreen";
 import NetworkGuideScreen from "./src/screen/NetworkGuideScreen";
+import PcListScreen from "./src/screen/PcListScreen";
 
 export default function App() {
   const Stack = createNativeStackNavigator();
@@ -52,6 +53,7 @@ export default function App() {
           component={DesktopAppDownloadScreen}
         />
         <Stack.Screen name="Network" component={NetworkGuideScreen} />
+        <Stack.Screen name="PcList" component={PcListScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/screen/DesktopAppDownloadScreen.js
+++ b/src/screen/DesktopAppDownloadScreen.js
@@ -125,7 +125,7 @@ const DesktopAppDescriptionText = styled.Text`
 
 const DesktopAppPreviousScreenButton = styled.TouchableOpacity`
   position: absolute;
-  top: 40px;
+  top: 50px;
   left: 20px;
 `;
 
@@ -144,7 +144,7 @@ const DesktopAppDescriptionBox = styled.View`
 
 const DesktopAppLogoutScreenButton = styled.TouchableOpacity`
   position: absolute;
-  top: 40px;
+  top: 50px;
   right: 20px;
 `;
 
@@ -175,16 +175,17 @@ const UserEmailPlaceHolder = styled.Text`
 `;
 
 const DesktopAppNextScreenButton = styled.TouchableOpacity`
-  width: 170px;
-  height: 50px;
-  margin-top: 40px;
+  display: flex;
   justify-content: center;
   align-items: center;
+  flex-direction: row;
+  margin-top: 30px;
+  padding: 10px 60px;
   background-color: #7e94ae;
   border-radius: 10px;
 `;
 
 const DesktopAppNextScreenButtonText = styled.Text`
-  font-size: 25px;
+  font-size: 20px;
   color: #f3eee6;
 `;

--- a/src/screen/DownloadGuideScreen.js
+++ b/src/screen/DownloadGuideScreen.js
@@ -6,8 +6,8 @@ import { Alert } from "react-native";
 import { useState } from "react";
 import { SERVER_PORT } from "@env";
 
-export default function DesktopAppDownloadScreen({ navigation }) {
-  const [text, onChangeText] = useState("");
+export default function DownloadGuideScreen({ navigation }) {
+  const [email, setUserEmail] = useState("");
   const [isFocus, setIsFocus] = useState(false);
 
   const logoutAlert = async () => {
@@ -31,7 +31,8 @@ export default function DesktopAppDownloadScreen({ navigation }) {
             text: "확인",
           },
         ]);
-        onChangeText(text);
+
+        setUserEmail(text);
 
         return false;
       } else {
@@ -59,107 +60,113 @@ export default function DesktopAppDownloadScreen({ navigation }) {
   };
 
   return (
-    <DesktopAppContainer>
-      <DesktopAppPreviousScreenButton
+    <DownloadGuideContainer>
+      <DownloadGuidePreviousScreenButton
         onPress={() => navigation.navigate("Main")}
       >
         <Ionicons name="arrow-back" size={32} color="#7e94ae" />
-      </DesktopAppPreviousScreenButton>
-      <DesktopAppLogoutScreenButton onPress={logoutAlert}>
-        <DesktopAppLogoutButtonText>Logout</DesktopAppLogoutButtonText>
-      </DesktopAppLogoutScreenButton>
+      </DownloadGuidePreviousScreenButton>
+      <DownloadGuideLogoutButton onPress={logoutAlert}>
+        <DownloadGuideLogoutButtonText>Logout</DownloadGuideLogoutButtonText>
+      </DownloadGuideLogoutButton>
       <Ionicons name="download-outline" size={150} color="#7e94ae" />
-      <DesktopAppTitleBox>
-        <DesktopAppTitleText>본 어플리케이션은 데스크탑에</DesktopAppTitleText>
-        <DesktopAppTitleText>프로그램설치가 필요합니다.</DesktopAppTitleText>
-      </DesktopAppTitleBox>
-      <DesktopAppDescriptionBox>
-        <DesktopAppDescriptionText>
+      <DownloadGuideTitleBox>
+        <DownloadGuideTitleText>
+          본 어플리케이션은 데스크탑에
+        </DownloadGuideTitleText>
+        <DownloadGuideTitleText>
+          프로그램설치가 필요합니다.
+        </DownloadGuideTitleText>
+      </DownloadGuideTitleBox>
+      <DownloadGuideDescriptionBox>
+        <DownloadGuideDescriptionText>
           아래에 Email을 입력하시면
-        </DesktopAppDescriptionText>
-        <DesktopAppDescriptionText>
+        </DownloadGuideDescriptionText>
+        <DownloadGuideDescriptionText>
           데스크탑 프로그램 설치파일이 전송됩니다.
-        </DesktopAppDescriptionText>
-      </DesktopAppDescriptionBox>
-      <UserEmailBox>
+        </DownloadGuideDescriptionText>
+      </DownloadGuideDescriptionBox>
+      <DownloadGuideUserEmailBox>
         <Ionicons name="mail-outline" size={30} color="#7e94ae" />
-        <UserEmailTextInput
-          onChangeText={onChangeText}
+        <DownloadGuideUserEmailTextInput
+          onChangeText={setUserEmail}
           onFocus={() => setIsFocus(true)}
           onBlur={() => setIsFocus(false)}
-          value={text}
+          value={email}
         />
-        <UserEmailPlaceHolder
+        <DownloadGuideUserEmailPlaceHolder
           style={isFocus ? { top: -10, left: 35 } : { left: 40 }}
         >
           Email
-        </UserEmailPlaceHolder>
+        </DownloadGuideUserEmailPlaceHolder>
         <Ionicons
           name="arrow-forward"
           size={24}
           color="#7e94ae"
-          onPress={() => validateEmail(text)}
+          onPress={() => validateEmail(email)}
         />
-      </UserEmailBox>
-      <DesktopAppNextScreenButton onPress={toNextScreen}>
-        <DesktopAppNextScreenButtonText>Next</DesktopAppNextScreenButtonText>
-      </DesktopAppNextScreenButton>
-    </DesktopAppContainer>
+      </DownloadGuideUserEmailBox>
+      <DownloadGuideNextScreenButton onPress={toNextScreen}>
+        <DownloadGuideNextScreenButtonText>
+          Next
+        </DownloadGuideNextScreenButtonText>
+      </DownloadGuideNextScreenButton>
+    </DownloadGuideContainer>
   );
 }
 
-const DesktopAppContainer = styled.View`
+const DownloadGuideContainer = styled.View`
   flex: 1;
   justify-content: center;
   align-items: center;
   background-color: #f3eee6;
 `;
 
-const DesktopAppTitleText = styled.Text`
+const DownloadGuideTitleText = styled.Text`
   font-size: 20px;
 `;
 
-const DesktopAppDescriptionText = styled.Text`
+const DownloadGuideDescriptionText = styled.Text`
   font-size: 12px;
 `;
 
-const DesktopAppPreviousScreenButton = styled.TouchableOpacity`
+const DownloadGuidePreviousScreenButton = styled.TouchableOpacity`
   position: absolute;
   top: 50px;
   left: 20px;
 `;
 
-const DesktopAppTitleBox = styled.View`
+const DownloadGuideTitleBox = styled.View`
   justify-content: center;
   align-items: center;
   margin-top: 50px;
   margin-bottom: 30px;
 `;
 
-const DesktopAppDescriptionBox = styled.View`
+const DownloadGuideDescriptionBox = styled.View`
   justify-content: center;
   align-items: center;
   margin-bottom: 30px;
 `;
 
-const DesktopAppLogoutScreenButton = styled.TouchableOpacity`
+const DownloadGuideLogoutButton = styled.TouchableOpacity`
   position: absolute;
   top: 50px;
   right: 20px;
 `;
 
-const DesktopAppLogoutButtonText = styled.Text`
+const DownloadGuideLogoutButtonText = styled.Text`
   margin-left: 10px;
   font-size: 20px;
   color: #7e94ae;
 `;
 
-const UserEmailBox = styled.View`
+const DownloadGuideUserEmailBox = styled.View`
   flex-direction: row;
   align-items: center;
 `;
 
-const UserEmailTextInput = styled.TextInput`
+const DownloadGuideUserEmailTextInput = styled.TextInput`
   width: 200px;
   height: 50px;
   padding: 10px;
@@ -168,13 +175,13 @@ const UserEmailTextInput = styled.TextInput`
   box-sizing: border-box;
 `;
 
-const UserEmailPlaceHolder = styled.Text`
+const DownloadGuideUserEmailPlaceHolder = styled.Text`
   position: absolute;
   font-size: 15px;
   color: #999999;
 `;
 
-const DesktopAppNextScreenButton = styled.TouchableOpacity`
+const DownloadGuideNextScreenButton = styled.TouchableOpacity`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -185,7 +192,7 @@ const DesktopAppNextScreenButton = styled.TouchableOpacity`
   border-radius: 10px;
 `;
 
-const DesktopAppNextScreenButtonText = styled.Text`
+const DownloadGuideNextScreenButtonText = styled.Text`
   font-size: 20px;
   color: #f3eee6;
 `;

--- a/src/screen/LoginScreen.js
+++ b/src/screen/LoginScreen.js
@@ -102,7 +102,7 @@ const LoginLoginButtonText = styled.Text`
 
 const LoginPreviousScreenButton = styled.TouchableOpacity`
   position: absolute;
-  top: 40px;
+  top: 50px;
   left: 20px;
 `;
 

--- a/src/screen/LoginScreen.js
+++ b/src/screen/LoginScreen.js
@@ -33,7 +33,7 @@ export default function LoginScreen({ navigation }) {
     const idToken = await AsyncStorage.getItem("idToken");
 
     if (idToken) {
-      navigation.navigate("DesktopAppDownload");
+      navigation.navigate("DownloadGuide");
     } else {
       Alert.alert("Need Login", "로그인이 필요합니다.", [
         {

--- a/src/screen/NetworkGuideScreen.js
+++ b/src/screen/NetworkGuideScreen.js
@@ -30,54 +30,54 @@ export default function NetworkGuideScreen({ navigation }) {
   };
 
   return (
-    <NetworkContainer>
-      <NetworkPreviousScreenButton
+    <NetworkGuideContainer>
+      <NetworkGuidePreviousScreenButton
         onPress={() => navigation.navigate("DesktopAppDownload")}
       >
         <Ionicons name="arrow-back" size={32} color="#7e94ae" />
-      </NetworkPreviousScreenButton>
-      <NetworkLogoutButton onPress={logoutAlert}>
-        <NetworkLogoutButtonText>Logout</NetworkLogoutButtonText>
-      </NetworkLogoutButton>
+      </NetworkGuidePreviousScreenButton>
+      <NetworkGuideLogoutButton onPress={logoutAlert}>
+        <NetworkGuideLogoutButtonText>Logout</NetworkGuideLogoutButtonText>
+      </NetworkGuideLogoutButton>
       <Ionicons name="wifi" size={150} color="#7e94ae" />
-      <NetworkTextBox>
-        <NetworkText>본 어플리케이션은</NetworkText>
-        <NetworkText>데스크탑과 디바이스가</NetworkText>
-        <NetworkText>서로 같은 네트워크에</NetworkText>
-        <NetworkText>연결되어있어야 합니다.</NetworkText>
-      </NetworkTextBox>
-      <NetworkNextButton onPress={toNextScreen}>
-        <NetworkNextButtonText>Next</NetworkNextButtonText>
-      </NetworkNextButton>
-    </NetworkContainer>
+      <NetworkGuideTextBox>
+        <NetworkGuideText>본 어플리케이션은</NetworkGuideText>
+        <NetworkGuideText>데스크탑과 디바이스가</NetworkGuideText>
+        <NetworkGuideText>서로 같은 네트워크에</NetworkGuideText>
+        <NetworkGuideText>연결되어있어야 합니다.</NetworkGuideText>
+      </NetworkGuideTextBox>
+      <NetworkGuideNextButton onPress={toNextScreen}>
+        <NetworkGuideNextButtonText>Next</NetworkGuideNextButtonText>
+      </NetworkGuideNextButton>
+    </NetworkGuideContainer>
   );
 }
 
-const NetworkContainer = styled.View`
+const NetworkGuideContainer = styled.View`
   flex: 1;
   justify-content: center;
   align-items: center;
   background-color: #f3eee6;
 `;
 
-const NetworkPreviousScreenButton = styled.TouchableOpacity`
+const NetworkGuidePreviousScreenButton = styled.TouchableOpacity`
   position: absolute;
   top: 50px;
   left: 20px;
 `;
 
-const NetworkLogoutButton = styled.TouchableOpacity`
+const NetworkGuideLogoutButton = styled.TouchableOpacity`
   position: absolute;
   top: 50px;
   right: 20px;
 `;
-const NetworkLogoutButtonText = styled.Text`
+const NetworkGuideLogoutButtonText = styled.Text`
   font-size: 20px;
   margin-right: 10px;
   color: #7e94ae;
 `;
 
-const NetworkTextBox = styled.View`
+const NetworkGuideTextBox = styled.View`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -85,13 +85,13 @@ const NetworkTextBox = styled.View`
   margin-bottom: 50px;
 `;
 
-const NetworkText = styled.Text`
+const NetworkGuideText = styled.Text`
   font-size: 20px;
   text-align: center;
   color: #333333;
 `;
 
-const NetworkNextButton = styled.TouchableOpacity`
+const NetworkGuideNextButton = styled.TouchableOpacity`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -102,7 +102,7 @@ const NetworkNextButton = styled.TouchableOpacity`
   border-radius: 10px;
 `;
 
-const NetworkNextButtonText = styled.Text`
+const NetworkGuideNextButtonText = styled.Text`
   font-size: 20px;
   color: #f3eee6;
 `;

--- a/src/screen/NetworkGuideScreen.js
+++ b/src/screen/NetworkGuideScreen.js
@@ -40,12 +40,12 @@ export default function NetworkGuideScreen({ navigation }) {
         <NetworkLogoutButtonText>Logout</NetworkLogoutButtonText>
       </NetworkLogoutButton>
       <Ionicons name="wifi" size={150} color="#7e94ae" />
-      <NetworkText>
-        본 어플리케이션은{"\n"}
-        데스크탑과 디바이스가{"\n"}
-        서로 같은 네트워크에{"\n"}
-        연결되어있어야 합니다.{"\n"}
-      </NetworkText>
+      <NetworkTextBox>
+        <NetworkText>본 어플리케이션은</NetworkText>
+        <NetworkText>데스크탑과 디바이스가</NetworkText>
+        <NetworkText>서로 같은 네트워크에</NetworkText>
+        <NetworkText>연결되어있어야 합니다.</NetworkText>
+      </NetworkTextBox>
       <NetworkNextButton onPress={toNextScreen}>
         <NetworkNextButtonText>Next</NetworkNextButtonText>
       </NetworkNextButton>
@@ -62,13 +62,13 @@ const NetworkContainer = styled.View`
 
 const NetworkPreviousScreenButton = styled.TouchableOpacity`
   position: absolute;
-  top: 40px;
+  top: 50px;
   left: 20px;
 `;
 
 const NetworkLogoutButton = styled.TouchableOpacity`
   position: absolute;
-  top: 40px;
+  top: 50px;
   right: 20px;
 `;
 const NetworkLogoutButtonText = styled.Text`
@@ -77,10 +77,18 @@ const NetworkLogoutButtonText = styled.Text`
   color: #7e94ae;
 `;
 
-const NetworkText = styled.Text`
+const NetworkTextBox = styled.View`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
   margin-bottom: 50px;
-  font-size: 24px;
+`;
+
+const NetworkText = styled.Text`
+  font-size: 20px;
   text-align: center;
+  color: #333333;
 `;
 
 const NetworkNextButton = styled.TouchableOpacity`
@@ -89,7 +97,7 @@ const NetworkNextButton = styled.TouchableOpacity`
   align-items: center;
   flex-direction: row;
   margin-top: 30px;
-  padding: 15px 50px;
+  padding: 10px 60px;
   background-color: #7e94ae;
   border-radius: 10px;
 `;

--- a/src/screen/PcListScreen.js
+++ b/src/screen/PcListScreen.js
@@ -1,0 +1,200 @@
+import { useEffect, useState } from "react";
+import { Alert, ScrollView } from "react-native";
+import styled from "styled-components/native";
+import axios from "axios";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { SERVER_PORT } from "@env";
+import { io } from "socket.io-client";
+
+export default function PcListScreen({ navigation }) {
+  const [recentPC, setRecentPc] = useState(null);
+  const [ipList, setIpList] = useState([]);
+
+  const logoutAlert = async () => {
+    await AsyncStorage.clear();
+
+    Alert.alert("Logout", "로그아웃이 완료되었습니다.", [
+      {
+        text: "확인",
+        onPress: () => navigation.navigate("Main"),
+      },
+    ]);
+  };
+
+  const connectPc = async (pc) => {
+    try {
+      const params = { max: 1, by: "connected_at", order: "asc" };
+
+      const idToken = await AsyncStorage.getItem("idToken");
+
+      await axios.post(
+        `${SERVER_PORT}/users/${JSON.parse(idToken).user.email}/pc`,
+        { recentPc: { name: pc.ip, ipAddress: pc.ip } },
+        { params },
+      );
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const params = { max: 1, by: "connected_at", order: "asc" };
+
+        const idToken = await AsyncStorage.getItem("idToken");
+        const recentPc = await axios.get(
+          `${SERVER_PORT}/users/${JSON.parse(idToken).user.email}/pc`,
+          { params },
+        );
+
+        setRecentPc(() => recentPc.data.recentPc);
+
+        const connectableIp = await axios.get(`${SERVER_PORT}/pcList/`);
+
+        for (let i = 0; i < connectableIp.data.localIpAddress.length; i++) {
+          const socket = io(
+            `http://${connectableIp.data.localIpAddress[i].ip}:8080`,
+          );
+
+          socket.emit("verifyConnectable");
+
+          socket.on("broadcast", (data) => {
+            console.log("socket.on ~ data", data);
+          });
+
+          socket.disconnect();
+        }
+
+        setIpList(() => connectableIp.data.localIpAddress);
+      } catch (error) {
+        console.error(error);
+      }
+    })();
+  }, []);
+
+  return (
+    <PcListContainer>
+      <PcListPreviousScreenButton
+        onPress={() => navigation.navigate("Network")}
+      >
+        <Ionicons name="arrow-back" size={32} color="#7e94ae" />
+      </PcListPreviousScreenButton>
+      <PcListLogoutScreenButton onPress={logoutAlert}>
+        <PcListLogoutButtonText>Logout</PcListLogoutButtonText>
+      </PcListLogoutScreenButton>
+      <PcListTitleBox>
+        <PcListTitleText>Select PC</PcListTitleText>
+      </PcListTitleBox>
+      <PcListBox>
+        <ScrollView>
+          {ipList?.map((value, index) => {
+            return (
+              <PcListPc
+                key={index}
+                onPress={() => {
+                  connectPc(value);
+                  navigation.navigate("TrackPad", { ipAddress: value?.ip });
+                }}
+              >
+                <Ionicons name="desktop-sharp" size={30} color="#7e94ae" />
+                <PcListPcName>{value?.ip}</PcListPcName>
+              </PcListPc>
+            );
+          })}
+        </ScrollView>
+      </PcListBox>
+      <PcListHorizonLine />
+      <PcListTitleBox>
+        <PcListTitleText>Recent PC</PcListTitleText>
+      </PcListTitleBox>
+      {recentPC?.name && (
+        <PcListPc
+          onPress={() => {
+            navigation.navigate("TrackPad", { ipAddress: recentPC?.name });
+          }}
+        >
+          <Ionicons name="desktop-sharp" size={30} color="#7e94ae" />
+          <PcListPcName>{recentPC?.name}</PcListPcName>
+          <PcListPcDate>
+            {new Date(recentPC?.lastAccessDate).toLocaleString("ko-KR")}
+          </PcListPcDate>
+        </PcListPc>
+      )}
+    </PcListContainer>
+  );
+}
+
+const PcListContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: #f3eee6;
+`;
+
+const PcListTitleText = styled.Text`
+  font-size: 50px;
+`;
+
+const PcListPreviousScreenButton = styled.TouchableOpacity`
+  position: absolute;
+  top: 50px;
+  left: 20px;
+`;
+
+const PcListTitleBox = styled.View`
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 30px;
+  color: #333333;
+`;
+
+const PcListBox = styled.View`
+  justify-content: flex-start;
+  align-items: center;
+  height: 150px;
+  width: 200px;
+`;
+
+const PcListPc = styled.TouchableOpacity`
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 20px;
+  width: 160px;
+`;
+
+const PcListPcName = styled.Text`
+  margin-left: 10px;
+  font-size: 20px;
+  color: #333333;
+`;
+
+const PcListPcDate = styled.Text`
+  position: absolute;
+  transform: translateX(32px) translateY(20px);
+  margin-left: 10px;
+  font-size: 10px;
+  color: #333333;
+`;
+
+const PcListHorizonLine = styled.View`
+  margin-top: 50px;
+  margin-bottom: 40px;
+  width: 200px;
+  border: 1.2px solid #999999;
+  opacity: 0.5;
+`;
+
+const PcListLogoutButtonText = styled.Text`
+  margin-left: 10px;
+  font-size: 20px;
+  color: #7e94ae;
+`;
+
+const PcListLogoutScreenButton = styled.TouchableOpacity`
+  position: absolute;
+  top: 50px;
+  right: 20px;
+`;


### PR DESCRIPTION
# Topic
- PC 연결 스크린 완성

# Detail
- 현 Local IP중 Package가 실행되어있는 IP를 가져오는 기능 구현
- 유저가 최근 접속했던 PC를 볼 수 있음.
![Screenshot_20221019-164008_Expo Go](https://user-images.githubusercontent.com/99075014/196628187-5d4e3e89-0056-4884-9ef2-39e60fb44261.jpg)

# Kanban Link
https://www.notion.so/vanillacoding/Layout-PC-361411513bba48d2ac537b023d9f7691

# Kanban List
- [x]  현재 연결할 수 있는 PC목록이 보인다.
- [x]  서버에서 Local IP목록을 가져온 뒤 Socket을 통해 현재 연결할 수 있는 PC목록을 갱신한다.
- [x]  최근에 연결했었던 PC가 보인다.
- [x]  해당 IP를 누르면 연결이 된다.

# ETC
- 연결할 수 있는 PC를 불러오는것이 실시간으로 갱신되지 않아 Refresh버튼을 이용해 갱신하여야함.
개선이 필요함.