### PR TITLE
[2022.10.19] TouchPad 페이지 layout 완성

### DIFF
--- a/App.js
+++ b/App.js
@@ -6,6 +6,7 @@ import LoginScreen from "./src/screen/LoginScreen";
 import DownloadGuideScreen from "./src/screen/DownloadGuideScreen";
 import NetworkGuideScreen from "./src/screen/NetworkGuideScreen";
 import PcListScreen from "./src/screen/PcListScreen";
+import TouchPadScreen from "./src/screen/TouchPadScreen";
 
 export default function App() {
   const Stack = createNativeStackNavigator();
@@ -22,6 +23,7 @@ export default function App() {
         <Stack.Screen name="DownloadGuide" component={DownloadGuideScreen} />
         <Stack.Screen name="Network" component={NetworkGuideScreen} />
         <Stack.Screen name="PcList" component={PcListScreen} />
+        <Stack.Screen name="TouchPad" component={TouchPadScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-client",
-  "version": "1.0.0",
+  "version": "0.9.1",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",

--- a/src/screen/DownloadGuideScreen.js
+++ b/src/screen/DownloadGuideScreen.js
@@ -6,7 +6,7 @@ import { Alert } from "react-native";
 import { useState } from "react";
 import { SERVER_PORT } from "@env";
 
-export default function DownloadGuideScreen({ navigation }) {
+const DownloadGuideScreen = ({ navigation }) => {
   const [email, setUserEmail] = useState("");
   const [isFocus, setIsFocus] = useState(false);
 
@@ -113,7 +113,7 @@ export default function DownloadGuideScreen({ navigation }) {
       </DownloadGuideNextScreenButton>
     </DownloadGuideContainer>
   );
-}
+};
 
 const DownloadGuideContainer = styled.View`
   flex: 1;
@@ -196,3 +196,5 @@ const DownloadGuideNextScreenButtonText = styled.Text`
   font-size: 20px;
   color: #f3eee6;
 `;
+
+export default DownloadGuideScreen;

--- a/src/screen/LoginScreen.js
+++ b/src/screen/LoginScreen.js
@@ -10,7 +10,7 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 
 WebBrowser.maybeCompleteAuthSession();
 
-export default function LoginScreen({ navigation }) {
+const LoginScreen = ({ navigation }) => {
   const [request, response, promptAsync] = Google.useAuthRequest({
     responseType: "id_token",
     expoClientId: EXPO_CLIENT_ID,
@@ -69,7 +69,7 @@ export default function LoginScreen({ navigation }) {
       </LoginLoginButton>
     </LoginContainer>
   );
-}
+};
 
 const LoginContainer = styled.View`
   flex: 1;
@@ -111,3 +111,5 @@ const LoginNextScreenButton = styled.TouchableOpacity`
   bottom: 40px;
   right: 20px;
 `;
+
+export default LoginScreen;

--- a/src/screen/MainScreen.js
+++ b/src/screen/MainScreen.js
@@ -1,6 +1,6 @@
 import styled from "styled-components/native";
 
-export default function MainScreen({ navigation }) {
+const MainScreen = ({ navigation }) => {
   return (
     <MainContainer>
       <MainTitleText>Portable</MainTitleText>
@@ -10,7 +10,7 @@ export default function MainScreen({ navigation }) {
       </MainLoginButton>
     </MainContainer>
   );
-}
+};
 
 const MainContainer = styled.View`
   flex: 1;
@@ -36,3 +36,5 @@ const MainLoginButtonText = styled.Text`
   font-size: 20px;
   color: #f3eee6;
 `;
+
+export default MainScreen;

--- a/src/screen/NetworkGuideScreen.js
+++ b/src/screen/NetworkGuideScreen.js
@@ -3,7 +3,7 @@ import { Alert } from "react-native";
 import styled from "styled-components/native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-export default function NetworkGuideScreen({ navigation }) {
+const NetworkGuideScreen = ({ navigation }) => {
   const logoutAlert = async () => {
     await AsyncStorage.clear();
 
@@ -51,7 +51,7 @@ export default function NetworkGuideScreen({ navigation }) {
       </NetworkGuideNextButton>
     </NetworkGuideContainer>
   );
-}
+};
 
 const NetworkGuideContainer = styled.View`
   flex: 1;
@@ -106,3 +106,5 @@ const NetworkGuideNextButtonText = styled.Text`
   font-size: 20px;
   color: #f3eee6;
 `;
+
+export default NetworkGuideScreen;

--- a/src/screen/PcListScreen.js
+++ b/src/screen/PcListScreen.js
@@ -7,7 +7,7 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 import { SERVER_PORT } from "@env";
 import { io } from "socket.io-client";
 
-export default function PcListScreen({ navigation }) {
+const PcListScreen = ({ navigation }) => {
   const [recentPC, setRecentPc] = useState(null);
   const [connectableIpList, setConnectableIpList] = useState([]);
 
@@ -134,7 +134,7 @@ export default function PcListScreen({ navigation }) {
       )}
     </PcListContainer>
   );
-}
+};
 
 const PcListContainer = styled.View`
   flex: 1;
@@ -219,3 +219,5 @@ const PcListLogoutScreenButton = styled.TouchableOpacity`
   top: 50px;
   right: 20px;
 `;
+
+export default PcListScreen;

--- a/src/screen/TouchPadScreen.js
+++ b/src/screen/TouchPadScreen.js
@@ -1,0 +1,47 @@
+import styled from "styled-components/native";
+import Ionicons from "@expo/vector-icons/Ionicons";
+
+export default function TouchPadScreen({ navigation }) {
+  return (
+    <TouchPadContainer>
+      <TouchPadPreviousScreenButton
+        onPress={() => navigation.navigate("PcList")}
+      >
+        <Ionicons name="arrow-back" size={32} color="#7e94ae" />
+      </TouchPadPreviousScreenButton>
+      <TouchPadSettingButton>
+        <Ionicons name="settings" size={24} color="#7e94ae" />
+      </TouchPadSettingButton>
+      <TrackPadTouchArea />
+    </TouchPadContainer>
+  );
+}
+
+const TouchPadContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: #f3eee6;
+`;
+
+const TouchPadPreviousScreenButton = styled.TouchableOpacity`
+  position: absolute;
+  top: 50px;
+  left: 20px;
+`;
+
+const TouchPadSettingButton = styled.TouchableOpacity`
+  position: absolute;
+  top: 50px;
+  right: 20px;
+`;
+
+const TrackPadTouchArea = styled.TouchableOpacity`
+  margin-top: 15%;
+  height: 80%;
+  width: 90%;
+  background-color: transparent;
+  border: 3px solid #7e94ae;
+  border-radius: 20px;
+  opacity: 0.2;
+`;

--- a/src/screen/TouchPadScreen.js
+++ b/src/screen/TouchPadScreen.js
@@ -1,7 +1,7 @@
 import styled from "styled-components/native";
 import Ionicons from "@expo/vector-icons/Ionicons";
 
-export default function TouchPadScreen({ navigation }) {
+const TouchPadScreen = ({ navigation }) => {
   return (
     <TouchPadContainer>
       <TouchPadPreviousScreenButton
@@ -15,7 +15,7 @@ export default function TouchPadScreen({ navigation }) {
       <TrackPadTouchArea />
     </TouchPadContainer>
   );
-}
+};
 
 const TouchPadContainer = styled.View`
   flex: 1;
@@ -45,3 +45,5 @@ const TrackPadTouchArea = styled.TouchableOpacity`
   border-radius: 20px;
   opacity: 0.2;
 `;
+
+export default TouchPadScreen;


### PR DESCRIPTION
# Topic
- TouchPad layout 완성

# Detail
- 터치패드로 이용할 수 있는 화면을 만든다.
- 왼쪽모서리는 이전 화면으로 갈 수 있는 버튼을, 오른쪽 모서리는 제스처에 대한 설정을 할 수 있도록 설정버튼을 만든다.

<img width="386" alt="image" src="https://user-images.githubusercontent.com/89302818/196676502-0394ffbe-99ed-471e-95f8-4f8f0f0d6eef.png">

# Kanban Link
https://www.notion.so/vanillacoding/Layout-1d2f58b9fccd44bfae2f54f2fb88f233

# Kanban List
- [x]  이전 화면으로 갈 수 있는 버튼을 만든다
- [x]  설정할 수 있는 설정버튼을 만든다.
- [x]  터치패드로 이용할 수 있는 화면구성을 만든다

# ETC
- 처음에 설계된 목업과 다르게 하단부 버튼을 없애기로 하였습니다.