### PR TITLE
[2022.10.20] Gesture 기본기능 구현 - Move

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-trackpad-client",
-  "version": "0.10.1",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-touchpad-client",
-  "version": "0.10.1",
+  "version": "0.11.1",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
# Topic
- Gesture 기본기능 구현 - Move

# Detail
- 사용자가 터치패드에서 한 손가락으로 터치 후 드래그 했을 시 이동이 되도록 기능을 구현한다.
  - package 서버로 사용자의 입력된 데이터 정보를 Socket을 통해 보내준다.

# Kanban Link
https://www.notion.so/vanillacoding/TouchPad-16cedeea27ea44e7a3d44987da42c219

# Kanban List
- [x]  유저가 한손가락으로 터치를 한 후 드래그를 할때 해당하는 이벤트의 React Native Gesture Handler 매서드를 찾는다.(이동)
- [x]  해당 매서드의 정보들을 Socket으로 보내준다.

# ETC
- 처음에 구성했던 [Gesture 기본기능 구현 - 클릭, 이동]에서 클릭과 이동을 별도로 분리하여 2개의 브랜치를 따로 만들기로 하였습니다.
- 클릭: https://github.com/Team-Saisiot/portable-trackpad-client/pull/10