### PR TITLE
[2022.10.21] Gesture 기본 기능 구현 - Scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-touchpad-client",
-  "version": "0.12.4",
+  "version": "0.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-touchpad-client",
-      "version": "0.11.1",
+      "version": "0.12.4",
       "dependencies": {
         "@expo/vector-icons": "^13.0.0",
         "@expo/webpack-config": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-touchpad-client",
-  "version": "0.12.4",
+  "version": "0.13.1",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",

--- a/src/screen/TouchPadScreen.js
+++ b/src/screen/TouchPadScreen.js
@@ -32,7 +32,11 @@ const TouchPadScreen = ({ navigation: { navigate }, route }) => {
   };
 
   const panGesture = Gesture.Pan();
+  const twoPointPanGesture = Gesture.Pan();
   const tapGesture = Gesture.Tap();
+
+  twoPointPanGesture.minPointers(2);
+  twoPointPanGesture.maxPointers(2);
 
   tapGesture.onTouchesUp((event) => {
     if (event.numberOfTouches === 0) {
@@ -67,7 +71,24 @@ const TouchPadScreen = ({ navigation: { navigate }, route }) => {
     }
   });
 
-  const composedGesture = Gesture.Race(panGesture, tapGesture);
+  twoPointPanGesture.onUpdate((event) => {
+    if (event.numberOfPointers === 2) {
+      socket.emit("user-send", [
+        "scroll",
+        0,
+        (parseInt(event.absoluteY) - yPosition.current) * 4,
+      ]);
+    }
+
+    xPosition.current = parseInt(event.absoluteX);
+    yPosition.current = parseInt(event.absoluteY);
+  });
+
+  const composedGesture = Gesture.Race(
+    twoPointPanGesture,
+    panGesture,
+    tapGesture,
+  );
 
   useFocusEffect(
     React.useCallback(() => {


### PR DESCRIPTION
# Topic
- Gesture 기본기능 구현 - Scroll

# Detail
- 사용자가 터치패드에서 두 손가락으로 터치 후 움직일 경우 화면을 스크롤할 수 있도록 기능을 구현한다.
- package 서버로 사용자의 입력된 데이터 정보를 Socket을 통해 보내준다.

# Kanban Link
https://www.notion.so/vanillacoding/TouchPad-41e81f2a1dfb46628a7cf2edfd8f273d

# Kanban List
- [x]  유저가 두 손가락으로 터치를 한 후 위아래로 드래그를 할때 해당하는 이벤트의 React Native Gesture Handler 매서드를 찾는다.
- [x]  해당 매서드의 정보를 Socket으로 보내준다.

# ETC
- 해당사항 없음