### PR TITLE
[2022.10.20] Gesture 기본기능 구현 - 브라우저 앞,뒤 이동

### DIFF
--- a/src/screen/TouchPadScreen.js
+++ b/src/screen/TouchPadScreen.js
@@ -87,6 +87,14 @@ const TouchPadScreen = ({ navigation: { navigate }, route }) => {
     yPosition.current = parseInt(event.absoluteY);
   });
 
+  twoPointPanGesture.onEnd((event) => {
+    if (event.translationX < 0 && Math.abs(event.translationY) < 10) {
+      socket.emit("user-send", ["goForwardInBrowser"]);
+    } else if (event.translationX > 0 && Math.abs(event.translationY) < 10) {
+      socket.emit("user-send", ["goBackInBrowser"]);
+    }
+  });
+
   rotationGesture.onUpdate((event) => {
     count++;
 


### PR DESCRIPTION
# Topic
- Gesture 기본기능 구현 - 브라우저 앞, 뒤 페이지 이동 기능

# Detail
- 사용자가 터치패드에서 두 손가락으로 앞방향으로 드래그 했을 떄 브라우저 앞 페이지를 보여준다.
- 사용자가 터치패드에서 두 손가락으로 뒷방향으로 드래그 했을 떄 브라우저 뒷 페이지를 보여준다.
- 위의 제스처에 해당하는 데이터 정보를 package 서버로 Socket을 통해 보내준다.

# Kanban Link
https://www.notion.so/vanillacoding/TouchPad-1a986c093c2e418d9409b06d429cde56

# Kanban List
- [x]  유저가 브라우저상에서 두손가락으로 터치를 한 후 좌우로 드래그하였을때 해당하는 이벤트의 React Native Gesture Handler 매서드를 찾는다.
- [x]  해당 매서드의 정보를 Socket으로 보내준다.

# ETC
- 해당사항 없음