### PR TITLE
[2022.10.22] Gesture 추가기능 구현 - 브라우저 탭 이동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-touchpad-client",
-  "version": "0.14.1",
+  "version": "0.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-touchpad-client",
-      "version": "0.13.1",
+      "version": "0.14.1",
       "dependencies": {
         "@expo/vector-icons": "^13.0.0",
         "@expo/webpack-config": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-touchpad-client",
-  "version": "0.14.1",
+  "version": "0.16.1",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
# Topic
- Gesture 추가기능 구현 - 브라우저 탭 이동 기능

# Detail
- 사용자가 터치패드에서 네 손가락으로 오른쪽에서 왼쪽으로 드래그하면 현재 탭에서 오른쪽 탭의 화면으로 이동한다.
- 사용자가 터치패드에서 네 손가락으로 왼쪽에서 오른쪽으로 드래그하면 현재 탭에서 왼쪽 탭의 화면으로 이동한다.
- 위의 제스처에 해당하는 데이터 정보를 package 서버로 Socket을 통해 보내준다.

# Kanban Link
https://www.notion.so/vanillacoding/TouchPad-b34fc6441ffe4d12bd9a7cc1dd50cfa9

# Kanban List
- [x]  유저가 브라우저상에서 네손가락으로 터치를 한 후 좌우로 드래그하였을때 해당하는 이벤트의 React Native Gesture Handler 매서드를 찾는다.
- [x]  해당 매서드의 정보를 Socket으로 보내준다.

# ETC
- 해당사항 없음