### PR TITLE
[2022.10.22] 도형모드 제스처 만들기

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-touchpad-client",
-  "version": "0.16.1",
+  "version": "0.17.1",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
# Topic
- 그림판 도명모드 제스처 만들기

# Detail
- 사용자가 터치패드에서 한 손가락으로 도형을 그렸을 시 pc화면에 뜨도록 하는 기능 구현.
- 사용자로부터 정보를 받아 도형을 인식할 수 있도록 로직 작성
- 인식된 도형 정보를 package서버로 Socket을 통해 전달.

# Kanban Link
https://www.notion.so/vanillacoding/8dcfd0351bea46ecb0b0b1a77b091b7c

# Kanban List
- [x]  터치패드에 원을 그리면 해당 제스처가 원임을 판단해서 package 서버에 보내줘야 한다.
- [x]  터치패드에 삼각형을 그리면 해당 제스처가 삼각형임을 판단해서 package 서버에 보내줘야 한다.
- [x]  터치패드에 사각형을 그리면 해당 제스처가 사각형임을 판단해서 package 서버에 보내줘야 한다.

# ETC
- 해당사항 없음